### PR TITLE
Added net6 target, upgraded dependencies & downgraded target framework

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -25,19 +25,13 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 6.0.x
         
     - name: Setup MSBuild.exe
       uses: microsoft/setup-msbuild@master
       with:
         vs-prerelease: true
         vs-version: 17
-        
-#     - name: Setup .NET
-#       uses: actions/setup-dotnet@v1
-#       with:
-#         dotnet-version: 6.0.x
-#         include-prerelease: true
         
     - name: Setup Scoop
       run: |

--- a/src/CommunityToolkit.Extensions.Hosting.WindowsAppSdk/CommunityToolkit.Extensions.Hosting.WindowsAppSdk.csproj
+++ b/src/CommunityToolkit.Extensions.Hosting.WindowsAppSdk/CommunityToolkit.Extensions.Hosting.WindowsAppSdk.csproj
@@ -2,27 +2,27 @@
 
   <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
-      <TargetFramework>net5.0-windows10.0.20348.0</TargetFramework>
-      <TargetPlatformMinVersion>10.0.20348.0</TargetPlatformMinVersion>
-      <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
-      <UseWinUI>true</UseWinUI>
-      <SupportedOSPlatformVersion>10.0.19041.0</SupportedOSPlatformVersion>
-      <PlatformTarget>x64</PlatformTarget>
-      <Platforms>x64</Platforms>
-      <LangVersion>10.0</LangVersion>
-      <RootNamespace>CommunityToolkit.Extensions.Hosting</RootNamespace>
-      <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-      <Company>Payton Byrd (The Sharp Ninja) &lt;ninja@thesharp.ninja&gt;</Company>
-      <Description>Allows hosting a Windows App SDK Application in an `IHost` that manages the lifecycle of the hosted Application.</Description>
-      <Copyright>2021 - All Rights Reserved</Copyright>
-      <PackageProjectUrl>https://github.com/sharpninja/WindowsAppSdkHost</PackageProjectUrl>
-      <PackageReadmeFile>README.md</PackageReadmeFile>
-      <RepositoryUrl>https://github.com/sharpninja/WindowsAppSdkHost</RepositoryUrl>
-      <RepositoryType>git</RepositoryType>
-      <PackageTags>WindowsAppSdk WinUI3 Hosting</PackageTags>
-      <PackageLicenseExpression>MIT</PackageLicenseExpression>
-      <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
-      <EnforceCodeStyleInBuild>True</EnforceCodeStyleInBuild>
+    <TargetFrameworks>net5.0-windows10.0.20348.0;net6.0-windows10.0.20348.0</TargetFrameworks>
+    <TargetPlatformMinVersion>10.0.20348.0</TargetPlatformMinVersion>
+    <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
+    <UseWinUI>true</UseWinUI>
+    <SupportedOSPlatformVersion>10.0.19041.0</SupportedOSPlatformVersion>
+    <PlatformTarget>x64</PlatformTarget>
+    <Platforms>x64</Platforms>
+    <LangVersion>10.0</LangVersion>
+    <RootNamespace>CommunityToolkit.Extensions.Hosting</RootNamespace>
+    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+    <Company>Payton Byrd (The Sharp Ninja) &lt;ninja@thesharp.ninja&gt;</Company>
+    <Description>Allows hosting a Windows App SDK Application in an `IHost` that manages the lifecycle of the hosted Application.</Description>
+    <Copyright>2021 - All Rights Reserved</Copyright>
+    <PackageProjectUrl>https://github.com/sharpninja/WindowsAppSdkHost</PackageProjectUrl>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <RepositoryUrl>https://github.com/sharpninja/WindowsAppSdkHost</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageTags>WindowsAppSdk WinUI3 Hosting</PackageTags>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
+    <EnforceCodeStyleInBuild>True</EnforceCodeStyleInBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/CommunityToolkit.Extensions.Hosting.WindowsAppSdk/CommunityToolkit.Extensions.Hosting.WindowsAppSdk.csproj
+++ b/src/CommunityToolkit.Extensions.Hosting.WindowsAppSdk/CommunityToolkit.Extensions.Hosting.WindowsAppSdk.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
-    <TargetFrameworks>net5.0-windows10.0.20348.0;net6.0-windows10.0.20348.0</TargetFrameworks>
+    <TargetFrameworks>net5.0-windows10.0.19041.0;net6.0-windows10.0.19041.0</TargetFrameworks>
     <TargetPlatformMinVersion>10.0.20348.0</TargetPlatformMinVersion>
     <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
     <UseWinUI>true</UseWinUI>
@@ -41,25 +41,19 @@
     </None>
   </ItemGroup>
 
-
-
   <ItemGroup>
     <PackageReference Include="GitVersion.MsBuild" Version="5.7.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0-rc.2.21480.5" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0-rc.2.21480.5" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.0.0-preview3" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.0.0" />
   </ItemGroup>
-
-
 
   <ItemGroup>
     <Resource Include="Strings.resx" />
   </ItemGroup>
-
-
 
   <ItemGroup>
     <Compile Update="Properties\Resources.Designer.cs">
@@ -68,8 +62,6 @@
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
   </ItemGroup>
-
-
 
   <ItemGroup>
     <EmbeddedResource Update="Properties\Resources.resx">

--- a/templates/HostedWindowsAppSdk.Installer/HostedWindowsAppSdk.Installer.wapproj
+++ b/templates/HostedWindowsAppSdk.Installer/HostedWindowsAppSdk.Installer.wapproj
@@ -50,7 +50,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22000.194" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.0.0-preview3" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\HostedWindowsAppSdk\HostedWindowsAppSdk.csproj" />

--- a/templates/HostedWindowsAppSdk/HostedWindowsAppSdk.csproj
+++ b/templates/HostedWindowsAppSdk/HostedWindowsAppSdk.csproj
@@ -30,7 +30,7 @@
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.Toolkit.Mvvm" Version="7.1.1" />
-        <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.0.0-preview3" />
+        <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.0.0" />
         <PackageReference Include="Microsoft.WindowsAppSDK.Foundation" Version="1.0.0-experimental1" />
         <PackageReference Include="Microsoft.WindowsAppSDK.InteractiveExperiences" Version="1.0.0-experimental1" />
         <Manifest Include="$(ApplicationManifest)" />


### PR DESCRIPTION
Hi sharpninja,

thanks for your amazing work!
I tried to use your package but noticed that it's compiled for net 5 only.

That's why I decided to create this PR to address this :)

I also did a few other minor changes:
* Upgraded GitHub flow (it's tailored to your account & registry; I haven't tested it!)
* Downgraded target framework to 10.0.19041.0 (that's the minimum version `Microsoft.WindowsAppSDK` supports). Otherwise, all projects are forced to raise their min version, too.
* Upgraded all Microsoft dependencies to the latest (non-preview) version.

I also suggest that you consider publishing to `nuget` instead of `github`. As far as I can tell, github requires users to add a nuget package ref for each registry. That means that if `n` projects (actually it's owner but who counts) use github's registry, you must add `n` registry references! 

Best regards,

Gitii