### PR TITLE
Refactor pipeline

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -13,6 +13,8 @@ jobs:
   publish-to-github:
     runs-on: windows-2022
     if: ${{ github.event_name != 'release' }}
+    env:
+      ARTIFACT_FOLDER: "${{ github.workspace }}/nuget"
     steps:
     - name: Event
       env:       
@@ -42,13 +44,13 @@ jobs:
       run: dotnet restore
       
     - name: Build Debug
-      run: msbuild /t:build /p:Configuration=Debug /p:PackageOutputPath=nuget /p:IncludeSource=true src/CommunityToolkit.Extensions.Hosting.WindowsAppSdk/CommunityToolkit.Extensions.Hosting.WindowsAppSdk.csproj
+      run: msbuild /t:build /p:Configuration=Debug /p:PackageOutputPath="${{ env:ARTIFACT_FOLDER }}" /p:IncludeSource=true src/CommunityToolkit.Extensions.Hosting.WindowsAppSdk/CommunityToolkit.Extensions.Hosting.WindowsAppSdk.csproj
       
     - name: GitHub Packages
       uses: tanaka-takayoshi/nuget-publish-to-github-packages-action@v2.1
       with:
         # Path of NuPkg
-        nupkg-path: './nuget/*.nupkg'
+        nupkg-path: '${{ env:ARTIFACT_FOLDER }}/*.nupkg'
         # package repository owner
         repo-owner: sharpninja
         # user account
@@ -61,6 +63,8 @@ jobs:
   publish-to-nuget:
     runs-on: windows-2022
     if: ${{ github.event_name == 'release' }}
+    env:
+      ARTIFACT_FOLDER: "${{ github.workspace }}/nuget"
     steps:
     - name: Event
       env:       
@@ -90,13 +94,13 @@ jobs:
       run: dotnet restore
       
     - name: Build
-      run: msbuild /t:build /p:Configuration=Release /p:PackageOutputPath=nuget /p:IncludeSource=true src/CommunityToolkit.Extensions.Hosting.WindowsAppSdk/CommunityToolkit.Extensions.Hosting.WindowsAppSdk.csproj
+      run: msbuild /t:build /p:Configuration=Release /p:PackageOutputPath="${{ env:ARTIFACT_FOLDER }}" /p:IncludeSource=true src/CommunityToolkit.Extensions.Hosting.WindowsAppSdk/CommunityToolkit.Extensions.Hosting.WindowsAppSdk.csproj
 
     - name: Attach nuget packages to Github releases
       uses: softprops/action-gh-release@v1
       with:
-        files: "./nuget/*.nupkg"
+        files: "${{ env:ARTIFACT_FOLDER }}/*.nupkg"
 
 #    - name: Nuget Publish
-#      run: dotnet nuget push "C:/nuget/*.nupkg" -k "${{ secrets.NUGET_KEY }}" -s https://api.nuget.org/v3/index.json --skip-duplicate
+#      run: dotnet nuget push "${{ env:ARTIFACT_FOLDER }}/*.nupkg" -k "${{ secrets.NUGET_KEY }}" -s https://api.nuget.org/v3/index.json --skip-duplicate
         

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -42,13 +42,13 @@ jobs:
       run: dotnet restore
       
     - name: Build Debug
-      run: msbuild /t:pack /p:Configuration=Debug /p:OutputPath=C:/nuget /p:IncludeSource=true src/CommunityToolkit.Extensions.Hosting.WindowsAppSdk/CommunityToolkit.Extensions.Hosting.WindowsAppSdk.csproj
+      run: msbuild /t:pack /p:Configuration=Debug /p:PackageOutputPath=nuget /p:IncludeSource=true src/CommunityToolkit.Extensions.Hosting.WindowsAppSdk/CommunityToolkit.Extensions.Hosting.WindowsAppSdk.csproj
       
     - name: GitHub Packages
       uses: tanaka-takayoshi/nuget-publish-to-github-packages-action@v2.1
       with:
         # Path of NuPkg
-        nupkg-path: 'C:/nuget/*.nupkg'
+        nupkg-path: './nuget/*.nupkg'
         # package repository owner
         repo-owner: sharpninja
         # user account
@@ -90,12 +90,12 @@ jobs:
       run: dotnet restore
       
     - name: Build
-      run: msbuild /t:pack /p:Configuration=Release /p:OutputPath=C:/nuget /p:IncludeSource=true src/CommunityToolkit.Extensions.Hosting.WindowsAppSdk/CommunityToolkit.Extensions.Hosting.WindowsAppSdk.csproj
+      run: msbuild /t:pack /p:Configuration=Release /p:PackageOutputPath=nuget /p:IncludeSource=true src/CommunityToolkit.Extensions.Hosting.WindowsAppSdk/CommunityToolkit.Extensions.Hosting.WindowsAppSdk.csproj
 
     - name: Attach nuget packages to Github releases
       uses: softprops/action-gh-release@v1
       with:
-        files: "C:/nuget/*.nupkg"
+        files: "./nuget/*.nupkg"
 
 #    - name: Nuget Publish
 #      run: dotnet nuget push "C:/nuget/*.nupkg" -k "${{ secrets.NUGET_KEY }}" -s https://api.nuget.org/v3/index.json --skip-duplicate

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -42,13 +42,16 @@ jobs:
       run: dotnet restore
       
     - name: Build Debug
-      run: msbuild /t:pack /p:Configuration=Debug /p:OutputPath=C:/nuget /p:IncludeSource=true src/CommunityToolkit.Extensions.Hosting.WindowsAppSdk/CommunityToolkit.Extensions.Hosting.WindowsAppSdk.csproj
+      run: msbuild /t:build /p:Configuration=Debug /p:IncludeSource=true src/CommunityToolkit.Extensions.Hosting.WindowsAppSdk/CommunityToolkit.Extensions.Hosting.WindowsAppSdk.csproj
+
+    - name: Pack
+      run: msbuild /t:pack /p:Configuration=Debug /p:OutputPath=nuget /p:IncludeSource=true src/CommunityToolkit.Extensions.Hosting.WindowsAppSdk/CommunityToolkit.Extensions.Hosting.WindowsAppSdk.csproj
       
     - name: GitHub Packages
       uses: tanaka-takayoshi/nuget-publish-to-github-packages-action@v2.1
       with:
         # Path of NuPkg
-        nupkg-path: 'C:/nuget/*.nupkg'
+        nupkg-path: './nuget/*.nupkg'
         # package repository owner
         repo-owner: sharpninja
         # user account
@@ -89,13 +92,16 @@ jobs:
     - name: Restore dependencies
       run: dotnet restore
       
-    - name: Build
-      run: msbuild /t:pack /p:Configuration=Release /p:OutputPath=C:/nuget /p:IncludeSource=true src/CommunityToolkit.Extensions.Hosting.WindowsAppSdk/CommunityToolkit.Extensions.Hosting.WindowsAppSdk.csproj
+    - name: Build Release
+      run: msbuild /t:build /p:Configuration=Release /p:IncludeSource=true src/CommunityToolkit.Extensions.Hosting.WindowsAppSdk/CommunityToolkit.Extensions.Hosting.WindowsAppSdk.csproj
+
+    - name: Pack
+      run: msbuild /t:pack /p:Configuration=Release /p:OutputPath=nuget /p:IncludeSource=true src/CommunityToolkit.Extensions.Hosting.WindowsAppSdk/CommunityToolkit.Extensions.Hosting.WindowsAppSdk.csproj
 
     - name: Attach nuget packages to Github releases
       uses: softprops/action-gh-release@v1
       with:
-        files: "C:/nuget/*.nupkg"
+        files: "./nuget/*.nupkg"
 
 #    - name: Nuget Publish
 #      run: dotnet nuget push "C:/nuget/*.nupkg" -k "${{ secrets.NUGET_KEY }}" -s https://api.nuget.org/v3/index.json --skip-duplicate

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -42,7 +42,7 @@ jobs:
       run: dotnet restore
       
     - name: Build Debug
-      run: dotnet ./src/CommunityToolkit.Extensions.Hosting.WindowsAppSdk/CommunityToolkit.Extensions.Hosting.WindowsAppSdk.csproj pack -c Debug --include-source -o $outPath C:/nuget
+      run: dotnet pack ./src/CommunityToolkit.Extensions.Hosting.WindowsAppSdk/CommunityToolkit.Extensions.Hosting.WindowsAppSdk.csproj -c Debug --include-source -o $outPath C:/nuget
       
     - name: GitHub Packages
       uses: tanaka-takayoshi/nuget-publish-to-github-packages-action@v2.1
@@ -90,8 +90,13 @@ jobs:
       run: dotnet restore
       
     - name: Build
-      run: dotnet ./src/CommunityToolkit.Extensions.Hosting.WindowsAppSdk/CommunityToolkit.Extensions.Hosting.WindowsAppSdk.csproj pack -c Release --include-source -o $outPath C:/nuget
+      run: dotnet pack ./src/CommunityToolkit.Extensions.Hosting.WindowsAppSdk/CommunityToolkit.Extensions.Hosting.WindowsAppSdk.csproj -c Release --include-source -o $outPath C:/nuget
 
-    - name: Nuget Publish
-      run: dotnet nuget push "C:/nuget/*.nupkg" -k "${{ secrets.NUGET_KEY }}" -s https://api.nuget.org/v3/index.json --skip-duplicate
+    - name: Attach nuget packages to Github releases
+      uses: softprops/action-gh-release@v1
+      with:
+        files: "C:/nuget/*.nupkg"
+
+#    - name: Nuget Publish
+#      run: dotnet nuget push "C:/nuget/*.nupkg" -k "${{ secrets.NUGET_KEY }}" -s https://api.nuget.org/v3/index.json --skip-duplicate
         

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -42,7 +42,7 @@ jobs:
       run: dotnet restore
       
     - name: Build Debug
-      run: dotnet pack ./src/CommunityToolkit.Extensions.Hosting.WindowsAppSdk/CommunityToolkit.Extensions.Hosting.WindowsAppSdk.csproj -c Debug --include-source -o $outPath C:/nuget
+      run: msbuild /t:pack /p:Configuration=Debug /p:OutputPath=C:/nuget /p:IncludeSource=true src/CommunityToolkit.Extensions.Hosting.WindowsAppSdk/CommunityToolkit.Extensions.Hosting.WindowsAppSdk.csproj
       
     - name: GitHub Packages
       uses: tanaka-takayoshi/nuget-publish-to-github-packages-action@v2.1
@@ -90,7 +90,7 @@ jobs:
       run: dotnet restore
       
     - name: Build
-      run: dotnet pack ./src/CommunityToolkit.Extensions.Hosting.WindowsAppSdk/CommunityToolkit.Extensions.Hosting.WindowsAppSdk.csproj -c Release --include-source -o $outPath C:/nuget
+      run: msbuild /t:pack /p:Configuration=Release /p:OutputPath=C:/nuget /p:IncludeSource=true src/CommunityToolkit.Extensions.Hosting.WindowsAppSdk/CommunityToolkit.Extensions.Hosting.WindowsAppSdk.csproj
 
     - name: Attach nuget packages to Github releases
       uses: softprops/action-gh-release@v1

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -42,7 +42,7 @@ jobs:
       run: dotnet restore
       
     - name: Build Debug
-      run: msbuild /t:pack /p:Configuration=Debug /p:PackageOutputPath=nuget /p:IncludeSource=true src/CommunityToolkit.Extensions.Hosting.WindowsAppSdk/CommunityToolkit.Extensions.Hosting.WindowsAppSdk.csproj
+      run: msbuild /t:build /p:Configuration=Debug /p:PackageOutputPath=nuget /p:IncludeSource=true src/CommunityToolkit.Extensions.Hosting.WindowsAppSdk/CommunityToolkit.Extensions.Hosting.WindowsAppSdk.csproj
       
     - name: GitHub Packages
       uses: tanaka-takayoshi/nuget-publish-to-github-packages-action@v2.1
@@ -90,7 +90,7 @@ jobs:
       run: dotnet restore
       
     - name: Build
-      run: msbuild /t:pack /p:Configuration=Release /p:PackageOutputPath=nuget /p:IncludeSource=true src/CommunityToolkit.Extensions.Hosting.WindowsAppSdk/CommunityToolkit.Extensions.Hosting.WindowsAppSdk.csproj
+      run: msbuild /t:build /p:Configuration=Release /p:PackageOutputPath=nuget /p:IncludeSource=true src/CommunityToolkit.Extensions.Hosting.WindowsAppSdk/CommunityToolkit.Extensions.Hosting.WindowsAppSdk.csproj
 
     - name: Attach nuget packages to Github releases
       uses: softprops/action-gh-release@v1

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -42,16 +42,13 @@ jobs:
       run: dotnet restore
       
     - name: Build Debug
-      run: msbuild /t:build /p:Configuration=Debug /p:IncludeSource=true src/CommunityToolkit.Extensions.Hosting.WindowsAppSdk/CommunityToolkit.Extensions.Hosting.WindowsAppSdk.csproj
-
-    - name: Pack
-      run: msbuild /t:pack /p:Configuration=Debug /p:OutputPath=nuget /p:IncludeSource=true src/CommunityToolkit.Extensions.Hosting.WindowsAppSdk/CommunityToolkit.Extensions.Hosting.WindowsAppSdk.csproj
+      run: msbuild /t:pack /p:Configuration=Debug /p:OutputPath=C:/nuget /p:IncludeSource=true src/CommunityToolkit.Extensions.Hosting.WindowsAppSdk/CommunityToolkit.Extensions.Hosting.WindowsAppSdk.csproj
       
     - name: GitHub Packages
       uses: tanaka-takayoshi/nuget-publish-to-github-packages-action@v2.1
       with:
         # Path of NuPkg
-        nupkg-path: './nuget/*.nupkg'
+        nupkg-path: 'C:/nuget/*.nupkg'
         # package repository owner
         repo-owner: sharpninja
         # user account
@@ -92,16 +89,13 @@ jobs:
     - name: Restore dependencies
       run: dotnet restore
       
-    - name: Build Release
-      run: msbuild /t:build /p:Configuration=Release /p:IncludeSource=true src/CommunityToolkit.Extensions.Hosting.WindowsAppSdk/CommunityToolkit.Extensions.Hosting.WindowsAppSdk.csproj
-
-    - name: Pack
-      run: msbuild /t:pack /p:Configuration=Release /p:OutputPath=nuget /p:IncludeSource=true src/CommunityToolkit.Extensions.Hosting.WindowsAppSdk/CommunityToolkit.Extensions.Hosting.WindowsAppSdk.csproj
+    - name: Build
+      run: msbuild /t:pack /p:Configuration=Release /p:OutputPath=C:/nuget /p:IncludeSource=true src/CommunityToolkit.Extensions.Hosting.WindowsAppSdk/CommunityToolkit.Extensions.Hosting.WindowsAppSdk.csproj
 
     - name: Attach nuget packages to Github releases
       uses: softprops/action-gh-release@v1
       with:
-        files: "./nuget/*.nupkg"
+        files: "C:/nuget/*.nupkg"
 
 #    - name: Nuget Publish
 #      run: dotnet nuget push "C:/nuget/*.nupkg" -k "${{ secrets.NUGET_KEY }}" -s https://api.nuget.org/v3/index.json --skip-duplicate

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -10,10 +10,9 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
-
+  publish-to-github:
     runs-on: windows-2022
-
+    if: ${{ github.event_name != 'release' }}
     steps:
     - name: Event
       env:       
@@ -41,37 +40,15 @@ jobs:
         
     - name: Restore dependencies
       run: dotnet restore
+      
     - name: Build Debug
-      if: ${{ github.event_name != 'release' }}
-      run: |
-        set-location ${{ github.workspace }}\src\CommunityToolkit.Extensions.Hosting.WindowsAppSdk
-        msbuild /t:Rebuild /p:Configuration=Debug,Platform=x64 .\CommunityToolkit.Extensions.Hosting.WindowsAppSdk.csproj
-    - name: Build Release
-      if: ${{ github.event_name == 'release' }}
-      run: |
-        set-location ${{ github.workspace }}\src\CommunityToolkit.Extensions.Hosting.WindowsAppSdk
-        msbuild /t:Rebuild /p:Configuration=Release,Platform=x64 .\CommunityToolkit.Extensions.Hosting.WindowsAppSdk.csproj
-        if(Test-File bin\x64\Debug\CommunityToolkit.Extensions.Hosting.WindowsAppSdk*.nupkg) {
-          $pkg = Get-ChildItem bin\x64\Debug\CommunityToolkit.Extensions.Hosting.WindowsAppSdk*.nupkg
-        }
-
-#     - name: Dotnet Debug Tests
-#       if: ${{ github.event_name != 'release' }}
-#       run: |
-#         set-location ${{ github.workspace }}\src\CommunityToolkit.Extensions.Hosting.WindowsAppSdk
-#         dotnet test -c Debug --no-build
-#     - name: Dotnet Release Tests
-#       if: ${{ github.event_name == 'release' }}
-#       run: |
-#         set-location ${{ github.workspace }}\src\CommunityToolkit.Extensions.Hosting.WindowsAppSdk
-#         dotnet test -c Release --no-build
-
+      run: dotnet ./src/CommunityToolkit.Extensions.Hosting.WindowsAppSdk/CommunityToolkit.Extensions.Hosting.WindowsAppSdk.csproj pack -c Debug --include-source -o $outPath C:/nuget
+      
     - name: GitHub Packages
-      if: ${{ github.event_name != 'release' }}
       uses: tanaka-takayoshi/nuget-publish-to-github-packages-action@v2.1
       with:
         # Path of NuPkg
-        nupkg-path: ${{ github.workspace }}\src\CommunityToolkit.Extensions.Hosting.WindowsAppSdk\bin\x64\Debug\CommunityToolkit.Extensions.Hosting.WindowsAppSdk.${{ env.GitVersion_SemVer }}.nupkg
+        nupkg-path: 'C:/nuget/*.nupkg'
         # package repository owner
         repo-owner: sharpninja
         # user account
@@ -80,21 +57,41 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
         # skip publishing duplicated package(s)
         skip-duplicate: true
+
+  publish-to-nuget:
+    runs-on: windows-2022
+    if: ${{ github.event_name == 'release' }}
+    steps:
+    - name: Event
+      env:       
+        event_name: ${{ github.event_name }}
+      run: echo "event_name $env:event_name"
+    - name: Checkout
+      uses: actions/checkout@v1
+      
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 6.0.x
         
+    - name: Setup MSBuild.exe
+      uses: microsoft/setup-msbuild@master
+      with:
+        vs-prerelease: true
+        vs-version: 17
+        
+    - name: Setup Scoop
+      run: |
+        iwr -useb get.scoop.sh | iex
+        scoop install gitversion
+        GitVersion
+        
+    - name: Restore dependencies
+      run: dotnet restore
+      
+    - name: Build
+      run: dotnet ./src/CommunityToolkit.Extensions.Hosting.WindowsAppSdk/CommunityToolkit.Extensions.Hosting.WindowsAppSdk.csproj pack -c Release --include-source -o $outPath C:/nuget
+
     - name: Nuget Publish
-      if: ${{ github.event_name == 'release' }}
-      run: | 
-        $outPath = (Join-Path . -Child packages)
-        set-location ${{ github.workspace }}\src\CommunityToolkit.Extensions.Hosting.WindowsAppSdk
-        dotnet pack -c Release --no-build --include-source -o $outPath 
-        
-        gci $outPath\*.nupkg -ErrorAction Stop
-        gci $outPath\*.snupkg -ErrorAction Stop
-        
-        gci $outPath\*.nupkg | forEach-Object -process {
-          dotnet nuget push $_ -k "${{ secrets.NUGET_KEY }}" -s https://api.nuget.org/v3/index.json --skip-duplicate
-        }
-        gci $outPath\*.snupkg | forEach-Object -process {
-          dotnet nuget push $_ -k "${{ secrets.NUGET_KEY }}" -s https://api.nuget.org/v3/index.json --skip-duplicate
-        }
+      run: dotnet nuget push "C:/nuget/*.nupkg" -k "${{ secrets.NUGET_KEY }}" -s https://api.nuget.org/v3/index.json --skip-duplicate
         

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -44,13 +44,13 @@ jobs:
       run: dotnet restore
       
     - name: Build Debug
-      run: msbuild /t:build /p:Configuration=Debug /p:PackageOutputPath="${{ env:ARTIFACT_FOLDER }}" /p:IncludeSource=true src/CommunityToolkit.Extensions.Hosting.WindowsAppSdk/CommunityToolkit.Extensions.Hosting.WindowsAppSdk.csproj
+      run: msbuild /t:build /p:Configuration=Debug /p:PackageOutputPath="${{ env.ARTIFACT_FOLDER }}" /p:IncludeSource=true src/CommunityToolkit.Extensions.Hosting.WindowsAppSdk/CommunityToolkit.Extensions.Hosting.WindowsAppSdk.csproj
       
     - name: GitHub Packages
       uses: tanaka-takayoshi/nuget-publish-to-github-packages-action@v2.1
       with:
         # Path of NuPkg
-        nupkg-path: '${{ env:ARTIFACT_FOLDER }}/*.nupkg'
+        nupkg-path: '${{ env.ARTIFACT_FOLDER }}/*.nupkg'
         # package repository owner
         repo-owner: sharpninja
         # user account
@@ -94,13 +94,13 @@ jobs:
       run: dotnet restore
       
     - name: Build
-      run: msbuild /t:build /p:Configuration=Release /p:PackageOutputPath="${{ env:ARTIFACT_FOLDER }}" /p:IncludeSource=true src/CommunityToolkit.Extensions.Hosting.WindowsAppSdk/CommunityToolkit.Extensions.Hosting.WindowsAppSdk.csproj
+      run: msbuild /t:build /p:Configuration=Release /p:PackageOutputPath="${{ env.ARTIFACT_FOLDER }}" /p:IncludeSource=true src/CommunityToolkit.Extensions.Hosting.WindowsAppSdk/CommunityToolkit.Extensions.Hosting.WindowsAppSdk.csproj
 
     - name: Attach nuget packages to Github releases
       uses: softprops/action-gh-release@v1
       with:
-        files: "${{ env:ARTIFACT_FOLDER }}/*.nupkg"
+        files: "${{ env.ARTIFACT_FOLDER }}/*.nupkg"
 
 #    - name: Nuget Publish
-#      run: dotnet nuget push "${{ env:ARTIFACT_FOLDER }}/*.nupkg" -k "${{ secrets.NUGET_KEY }}" -s https://api.nuget.org/v3/index.json --skip-duplicate
+#      run: dotnet nuget push "${{ env.ARTIFACT_FOLDER }}/*.nupkg" -k "${{ secrets.NUGET_KEY }}" -s https://api.nuget.org/v3/index.json --skip-duplicate
         

--- a/src/CommunityToolkit.Extensions.Hosting.WindowsAppSdk/CommunityToolkit.Extensions.Hosting.WindowsAppSdk.csproj
+++ b/src/CommunityToolkit.Extensions.Hosting.WindowsAppSdk/CommunityToolkit.Extensions.Hosting.WindowsAppSdk.csproj
@@ -7,8 +7,6 @@
     <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
     <UseWinUI>true</UseWinUI>
     <SupportedOSPlatformVersion>10.0.19041.0</SupportedOSPlatformVersion>
-    <PlatformTarget>x64</PlatformTarget>
-    <Platforms>x64</Platforms>
     <LangVersion>10.0</LangVersion>
     <RootNamespace>CommunityToolkit.Extensions.Hosting</RootNamespace>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>


### PR DESCRIPTION
Hi,

I noticed that the nuget packages are x64 only.
So I refactored the build pipeline:
* Included all supported architectures: x86, x64 and arm64
* Simplified job steps

The main difference between both jobs is the target & configuration: 
"debug" for github packages and "release" for github releases (and nuget hub) (as before).

I recommend using release configuration for both and rely on the symbol packages (snupkg) instead.
That would allow to merge both jobs.

I could not test this PR (missing credentials, of course), so if this PR is accepted, there needs to be at least one test run. 
Therefore, I disabled the nuget upload. Once the github release assets are available and verified, it can be enabled again. Otherwise, prerelease packages are uploaded to nuget.

Best regards 